### PR TITLE
release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Changelog history
 
+### 22nd February 2025 (release 0.3.0)
+
+* MAINTENANCE: Rust 2024 Edition enabled by default (2021 --> 2024)
+* MAINTENANCE: Crates updated
+* UPDATE: affinidi-did-resolver-cache-sdk
+  * tokio-tungstenite removed and replaced via web-socket crate
+  * Enables better low level error handling of the WebSocket. Especially when a device sleeps and detecting the WebSocket Channel has been closed.
+
 ### 12th February 2025 (release 0.2.9)
 
 * FIX: SDK Network loop would not exit when the MPSC Channel was closed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,8 +73,9 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-cache-sdk"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
+ "base64 0.22.1",
  "blake2",
  "clap",
  "did-example",
@@ -85,22 +86,27 @@ dependencies = [
  "number_prefix",
  "rand 0.9.0",
  "rayon",
+ "rustls 0.23.23",
+ "rustls-platform-verifier",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "sha1",
  "ssi",
  "thiserror 2.0.11",
  "tokio",
- "tokio-tungstenite",
+ "tokio-rustls 0.26.1",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-socket",
 ]
 
 [[package]]
 name = "affinidi-did-resolver-cache-server"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "affinidi-did-resolver-cache-sdk",
  "axum",
@@ -117,6 +123,7 @@ dependencies = [
  "ssi",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-rustls 0.26.1",
  "toml 0.8.20",
  "tower-http",
  "tracing",
@@ -125,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "affinidi-did-resolver-methods"
-version = "0.2.9"
+version = "0.3.0"
 
 [[package]]
 name = "ahash"
@@ -232,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
 
 [[package]]
 name = "arc-swap"
@@ -333,9 +340,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
+checksum = "4cd755adf9707cf671e31d944a189be3deaaeee11c8bc1d669bb8022ac90fbd0"
 dependencies = [
  "aws-lc-sys",
  "paste",
@@ -344,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ac4f13dad353b209b34cbec082338202cbc01c8f00336b55c750c13ac91f8f"
+checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
 dependencies = [
  "bindgen",
  "cc",
@@ -594,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "1230237285e3e10cde447185e8975408ae24deaa67205ce684805c25bc0c7937"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -723,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
 dependencies = [
  "jobserver",
  "libc",
@@ -740,6 +747,12 @@ checksum = "060303ef31ef4a522737e1b1ab68c67916f2a787bb2f4f54f383279adba962b5"
 dependencies = [
  "slab",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -860,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -870,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
@@ -929,6 +942,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "337cdbf3f1a0e643b4a7d1a2ffa39d22342fb6ee25739b5cfb997c28b3586422"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +995,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1136,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
@@ -1342,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "did-example"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "ssi",
  "thiserror 2.0.11",
@@ -1412,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "did-peer"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "askar-crypto",
  "base64 0.22.1",
@@ -1518,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "document-features"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
 dependencies = [
  "litrs",
 ]
@@ -1665,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1975,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2194,7 +2227,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
@@ -2497,9 +2530,9 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
@@ -2554,6 +2587,28 @@ name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -3081,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "loom"
@@ -3133,9 +3188,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -3236,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -3246,7 +3301,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3395,9 +3450,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -3436,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -3810,8 +3865,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.0",
- "zerocopy 0.8.17",
+ "rand_core 0.9.1",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -3831,7 +3886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.0",
+ "rand_core 0.9.1",
 ]
 
 [[package]]
@@ -3846,12 +3901,12 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
 dependencies = [
  "getrandom 0.3.1",
- "zerocopy 0.8.17",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -3871,9 +3926,9 @@ checksum = "d20581732dd76fa913c7dff1a2412b714afe3573e94d41c34719de73337cc8ab"
 
 [[package]]
 name = "raw-btree"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9a77e61cd9f37af08f952c1c072081563e129c0949ac4ede30f9e8b6b4b74f"
+checksum = "2fdead0382b742073dbbb295e93cdf7d25fbe281f0ca07988c64bee27d534a38"
 
 [[package]]
 name = "rayon"
@@ -3897,9 +3952,9 @@ dependencies = [
 
 [[package]]
 name = "rdf-types"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8d685353ee1b343c708b6be7751d98a7df8e1d0caaeee67c754318854c01d5"
+checksum = "4ccfa6b3af8f44db8d700038d47a9e8c8cc4126cdcafc069e82116903420631d"
 dependencies = [
  "contextual",
  "educe 0.5.11",
@@ -3915,9 +3970,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
 dependencies = [
  "bitflags 2.8.0",
 ]
@@ -4027,7 +4082,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
+ "h2 0.4.8",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -4072,15 +4127,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "d34b5020fcdea098ef7d95e9f89ec15952123a4a039badd09fabebe9e963e839"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -4169,11 +4223,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -4199,6 +4266,33 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e012c45844a1790332c9386ed4ca3a06def221092eda277e6f079728f8ea99da"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.23",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.102.8",
+ "security-framework 3.2.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4256,6 +4350,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4307,7 +4410,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4337,9 +4453,9 @@ checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
@@ -4395,9 +4511,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4417,9 +4533,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",
@@ -4631,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -5537,7 +5653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
@@ -5548,7 +5664,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.8.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -5586,9 +5702,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -5759,15 +5875,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
  "tokio",
- "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -5965,18 +6079,16 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413083a99c579593656008130e29255e54dcaae495be556cc26888f211648c24"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http 1.2.0",
  "httparse",
  "log",
- "native-tls",
- "rand 0.8.5",
+ "rand 0.9.0",
  "sha1",
  "thiserror 2.0.11",
  "utf-8",
@@ -5984,9 +6096,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "uint"
@@ -6002,9 +6114,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-xid"
@@ -6077,9 +6189,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+checksum = "93d59ca99a559661b96bf898d8fce28ed87935fd2bea9f05983c1464dd6c71b1"
 dependencies = [
  "getrandom 0.3.1",
 ]
@@ -6101,6 +6213,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -6198,6 +6320,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-socket"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4202f445611df275891e7575aa91b99ae4bedee6241af7020ce0a3c28cabc449"
+dependencies = [
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6205,6 +6337,15 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6240,6 +6381,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -6333,6 +6483,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -6356,6 +6515,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6391,6 +6565,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6403,6 +6583,12 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6412,6 +6598,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6433,6 +6625,12 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6442,6 +6640,12 @@ name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6457,6 +6661,12 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6466,6 +6676,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6481,9 +6697,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]
@@ -6593,11 +6809,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.17"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
 dependencies = [
- "zerocopy-derive 0.8.17",
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -6613,9 +6829,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.17"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ members = [
     "affinidi-did-resolver-cache-server",
     "affinidi-did-resolver-methods",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
-version = "0.2.9"
-edition = "2021"
+version = "0.3.0"
+edition = "2024"
 authors = ["Glenn Gore <glenn@affinidi.com>"]
 description = "Affinidi DID Resolver"
 readme = "README.md"
@@ -36,9 +36,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Cache Server
-affinidi-did-resolver-cache-sdk = { version = "0.2.9", path = "./affinidi-did-resolver-cache-sdk" }
-did-peer = { version = "0.2.9", path = "./affinidi-did-resolver-methods/did-peer" }
-did-example = { version = "0.2.9", path = "./affinidi-did-resolver-methods/did-example" }
+affinidi-did-resolver-cache-sdk = { version = "0.3", path = "./affinidi-did-resolver-cache-sdk" }
+did-peer = { version = "0.3", path = "./affinidi-did-resolver-methods/did-peer" }
+did-example = { version = "0.3", path = "./affinidi-did-resolver-methods/did-example" }
 axum = { version = "0.8", features = ["ws"] }
 axum-extra = { version = "0.10", features = ["typed-header"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
@@ -48,12 +48,20 @@ toml = "0.8"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 
 # Cache Client (SDK)
-futures-util = "0.3"
-tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
-rayon = "1.10"
-num-format = "0.4.4"
 clap = { version = "4.5", features = ["derive"] }
+futures-util = "0.3"
+num-format = "0.4.4"
 number_prefix = "0.4"
+rayon = "1.10"
+rustls = { version = "0.23", default-features = false, features = [
+    "aws_lc_rs",
+    "tls12",
+] }
+rustls-platform-verifier = "0.5"
+sha1 = "0.10"
+tokio-rustls = "0.26"
+url = "2.5"
+web-socket = "0.7"
 
 # DID methods
 askar-crypto = { version = "0.3", features = ["alloc"] }

--- a/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -17,27 +17,41 @@ crate-type = ["rlib", "cdylib"]
 [features]
 default = ["local"]
 local = []
-network = ["dep:tokio-tungstenite"]
+network = [
+    "dep:web-socket",
+    "dep:url",
+    "dep:sha1",
+    "dep:base64",
+    "dep:tokio-rustls",
+    "dep:rustls",
+    "dep:rustls-platform-verifier",
+]
 did_example = ["dep:did-example"]
 
 [dependencies]
+base64 = { workspace = true, optional = true }
 blake2.workspace = true
 did-peer.workspace = true
 did-example = { workspace = true, optional = true }
 futures-util.workspace = true
 moka.workspace = true
 rand.workspace = true
+rustls = { workspace = true, optional = true }
+rustls-platform-verifier = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 serde-wasm-bindgen.workspace = true
+sha1 = { workspace = true, optional = true }
 ssi.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-tokio-tungstenite = { workspace = true, optional = true }
+tokio-rustls = { workspace = true, optional = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
+url = { workspace = true, optional = true }
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
+web-socket = { workspace = true, optional = true }
 
 [dev-dependencies]
 clap.workspace = true

--- a/affinidi-did-resolver-cache-sdk/README.md
+++ b/affinidi-did-resolver-cache-sdk/README.md
@@ -89,7 +89,7 @@ You will need to enable the crate feature `network` to use Network Mode.
 
 A reference benchmark example is included that can be used to measure performance. To run this use the following:
 
-`cargo run --example benchmark -- -g 1000 -r 10000 -n ws://127.0.0.1:8080/did/v1/ws`
+`cargo run --features network --example benchmark -- -g 1000 -r 10000 -n ws://127.0.0.1:8080/did/v1/ws`
 
 Run the above from the $affinidi-did-resolver/affinidi-did-resolver-cache-sdk directory
 

--- a/affinidi-did-resolver-cache-sdk/src/networking/handshake.rs
+++ b/affinidi-did-resolver-cache-sdk/src/networking/handshake.rs
@@ -1,0 +1,128 @@
+//! # Client handshake request
+//!
+//! A client sends a handshake request to the server. It includes the following information:
+//!
+//! ```yml
+//! GET /chat HTTP/1.1
+//! Host: example.com:8000
+//! Upgrade: websocket
+//! Connection: Upgrade
+//! Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+//! Sec-WebSocket-Version: 13
+//! ```
+//!
+//! The server must be careful to understand everything the client asks for, otherwise security issues can occur.
+//! If any header is not understood or has an incorrect value, the server should send a 400 ("Bad Request")} response and immediately close the socket.
+//!
+//! ### Tips
+//!
+//! All browsers send an Origin header.
+//! You can use this header for security (checking for same origin, automatically allowing or denying, etc.) and send a 403 Forbidden if you don't like what you see.
+//! However, be warned that non-browser agents can send a faked Origin. Most applications reject requests without this header.
+//!
+//! Any http headers is allowed. (Do whatever you want with them)
+//!
+//! ### Note
+//!
+//! -  HTTP version must be `1.1` or greater, and method must be `GET`
+//! - `Host` header field containing the server's authority.
+//! - `Upgrade` header field containing the value `"websocket"`
+//! - `Connection` header field that includes the token `"Upgrade"`
+//! - `Sec-WebSocket-Version` header field containing the value `13`
+//! - `Sec-WebSocket-Key` header field with a base64-encoded value that, when decoded, is 16 bytes in length.
+//! -  Request may include any other header fields, for example, cookies and/or authentication-related header fields.
+//! -  Optionally, `Origin` header field.  This header field is sent by all browser clients.
+
+use sha1::{Digest, Sha1};
+use std::fmt;
+
+/// WebSocket magic string used during the WebSocket handshake
+pub const MAGIC_STRING: &[u8; 36] = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+/// Create `Sec-WebSocket-Accept` key from `Sec-WebSocket-Key` http header value.
+///
+/// ### Example
+///
+/// ```no_compile
+/// use crate::utils::handshake::accept_key_from;
+/// assert_eq!(accept_key_from("dGhlIHNhbXBsZSBub25jZQ=="), "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=");
+/// ```
+#[inline]
+pub fn accept_key_from(sec_ws_key: impl AsRef<[u8]>) -> String {
+    let mut sha1 = Sha1::new();
+    sha1.update(sec_ws_key.as_ref());
+    sha1.update(MAGIC_STRING);
+    base64_encode(sha1.finalize())
+}
+
+/// Create websocket handshake request
+///
+/// ### Example
+///
+/// ```no_compile
+/// use crate::utils::handshake::request;
+/// let _ = request("example.com", "/path", [("key", "value")]);
+/// ```
+///
+/// ### Output
+///
+/// ```yaml
+/// GET /path HTTP/1.1
+/// Host: example.com
+/// Upgrade: websocket
+/// Connection: Upgrade
+/// Sec-WebSocket-Version: 13
+/// Sec-WebSocket-Key: D3E1sFZlZfeZgNXtVHfhKg== # randomly generated
+/// key: value
+/// ...
+/// ```
+pub fn request(
+    host: impl AsRef<str>,
+    path: impl AsRef<str>,
+    headers: impl IntoIterator<Item = impl Header>,
+) -> (String, String) {
+    let host = host.as_ref();
+    let path = path.as_ref().trim_start_matches('/');
+    let sec_key = base64_encode(42_u128.to_ne_bytes());
+    let headers: String = headers.into_iter().map(|f| Header::fmt(&f)).collect();
+    (
+        format!(
+            "GET /{path} HTTP/1.1\r\nHost: {host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: {sec_key}\r\n{headers}\r\n"
+        ),
+        sec_key,
+    )
+}
+
+/// Provides a interface for formatting HTTP headers
+///
+/// # Example
+///
+/// ```no_compile
+///
+/// assert_eq!(Header::fmt(&("val", 2)), "val: 2\r\n");
+/// assert_eq!(Header::fmt(&["key", "value"]), "key: value\r\n");
+/// ```
+pub trait Header {
+    /// Format a single http header field
+    fn fmt(_: &Self) -> String;
+}
+
+impl<T: Header> Header for &T {
+    fn fmt(this: &Self) -> String {
+        T::fmt(this)
+    }
+}
+impl<T: fmt::Display> Header for [T; 2] {
+    fn fmt([key, value]: &Self) -> String {
+        format!("{key}: {value}\r\n")
+    }
+}
+impl<K: fmt::Display, V: fmt::Display> Header for (K, V) {
+    fn fmt((key, value): &Self) -> String {
+        format!("{key}: {value}\r\n")
+    }
+}
+
+fn base64_encode(string: impl AsRef<[u8]>) -> String {
+    base64::Engine::encode(&base64::prelude::BASE64_STANDARD, string)
+}

--- a/affinidi-did-resolver-cache-sdk/src/networking/mod.rs
+++ b/affinidi-did-resolver-cache-sdk/src/networking/mod.rs
@@ -5,16 +5,20 @@
 //!
 
 use network::WSCommands;
-use rand::{distr::Alphanumeric, Rng};
+use rand::{Rng, distr::Alphanumeric};
 use serde::{Deserialize, Serialize};
 use ssi::dids::Document;
 use tokio::{select, sync::oneshot};
-use tracing::{debug, span, warn, Instrument, Level};
+use tracing::{Instrument, Level, debug, span, warn};
 
-use crate::{errors::DIDCacheError, DIDCacheClient};
+use crate::{DIDCacheClient, errors::DIDCacheError};
+#[cfg(feature = "network")]
+pub(crate) mod handshake;
 pub mod network;
-mod request_queue;
+#[cfg(feature = "network")]
+pub(crate) mod utils;
 
+mod request_queue;
 /// WSRequest is the request format to the websocket connection
 /// did: DID to resolve
 #[derive(Debug, Deserialize, Serialize)]

--- a/affinidi-did-resolver-cache-sdk/src/networking/utils.rs
+++ b/affinidi-did-resolver-cache-sdk/src/networking/utils.rs
@@ -1,0 +1,167 @@
+use super::{handshake, network::ReadWrite};
+use crate::errors::DIDCacheError;
+use rustls::{
+    ClientConfig,
+    pki_types::{DnsName, ServerName},
+};
+use rustls_platform_verifier::ConfigVerifierExt;
+use std::{collections::HashMap, pin::Pin, sync::Arc};
+use tokio::{
+    io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader},
+    net::TcpStream,
+};
+use tokio_rustls::TlsConnector;
+use tracing::error;
+use url::Url;
+use web_socket::WebSocket;
+
+#[derive(Debug)]
+pub struct HttpRequest {
+    pub prefix: String,
+    headers: HashMap<String, String>,
+}
+
+impl std::ops::Deref for HttpRequest {
+    type Target = HashMap<String, String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.headers
+    }
+}
+
+impl std::ops::DerefMut for HttpRequest {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.headers
+    }
+}
+
+impl HttpRequest {
+    pub async fn parse<IO>(reader: &mut IO) -> Result<Self, DIDCacheError>
+    where
+        IO: Unpin + AsyncBufRead,
+    {
+        let mut lines = reader.lines();
+
+        let Some(prefix) = lines.next_line().await.map_err(|err| {
+            DIDCacheError::TransportError(format!(
+                "Incorrect response from WebSocket Setup: {}",
+                err
+            ))
+        })?
+        else {
+            return Err(DIDCacheError::TransportError(
+                "WebSocket Prefix not returned from server".into(),
+            ));
+        };
+
+        let mut headers = HashMap::new();
+
+        while let Some(line) = lines.next_line().await.map_err(|err| {
+            DIDCacheError::TransportError(format!(
+                "Incorrect response from WebSocket Setup: {}",
+                err
+            ))
+        })? {
+            if line.is_empty() {
+                break;
+            }
+            let (key, value) = line.split_once(":").unwrap();
+            headers.insert(key.to_ascii_lowercase(), value.trim_start().into());
+        }
+        Ok(Self { prefix, headers })
+    }
+}
+
+pub async fn connect(
+    url: &Url,
+) -> Result<WebSocket<BufReader<Pin<Box<dyn ReadWrite>>>>, DIDCacheError> {
+    let (host, path) = if let Some(host) = url.host() {
+        (host.to_string(), url.path().to_string())
+    } else {
+        error!("Websocket address {}: no valid host found", url);
+        return Err(DIDCacheError::TransportError(format!(
+            "Websocket address {}: no valid host found",
+            url
+        )));
+    };
+
+    let address = match url.socket_addrs(|| None) {
+        Ok(mut addrs) => {
+            if addrs.is_empty() {
+                error!("Websocket address {}: no valid address found", url);
+                return Err(DIDCacheError::TransportError(format!(
+                    "Websocket address {}: no valid address found",
+                    url
+                )));
+            }
+            addrs.remove(0)
+        }
+        Err(err) => {
+            error!("Websocket address {}: invalid address: {}", url, err);
+            return Err(DIDCacheError::TransportError(format!(
+                "Websocket address {}: invalid address: {}",
+                url, err
+            )));
+        }
+    };
+
+    let stream = TcpStream::connect(address).await.map_err(|err| {
+        DIDCacheError::TransportError(format!("TcpStream::Connect({}) failed: {}", address, err))
+    })?;
+
+    let stream: Pin<Box<dyn ReadWrite>> = if url.scheme() == "wss" {
+        // SSL/TLS Connection
+        let dns_name = match DnsName::try_from_str(host.as_str()) {
+            Ok(dns_name) => dns_name.to_owned(),
+            Err(err) => {
+                error!("Websocket address {}: invalid host name: {}", host, err);
+                return Err(DIDCacheError::TransportError(format!(
+                    "Websocket address {}: invalid host name: {}",
+                    host, err
+                )));
+            }
+        };
+
+        let connector = TlsConnector::from(Arc::new(ClientConfig::with_platform_verifier()));
+        Box::pin(
+            connector
+                .connect(ServerName::DnsName(dns_name), stream)
+                .await
+                .map_err(|err| {
+                    DIDCacheError::TransportError(format!(
+                        "TlsConnector::connect({}) failed: {}",
+                        host, err
+                    ))
+                })?,
+        )
+    } else {
+        Box::pin(stream)
+    };
+
+    let mut stream = BufReader::new(stream);
+
+    let (req, sec_key) = handshake::request(host, path, None::<(&str, &str)>);
+
+    stream.write_all(req.as_bytes()).await.map_err(|err| {
+        DIDCacheError::TransportError(format!("websocket handshake failed: {}", err))
+    })?;
+
+    let http = HttpRequest::parse(&mut stream).await?;
+
+    if !http.prefix.starts_with("HTTP/1.1 101 Switching Protocols") {
+        return Err(DIDCacheError::TransportError(
+            "expected upgrade connection".to_string(),
+        ));
+    }
+    if http
+        .get("sec-websocket-accept")
+        .expect("couldn't get `sec-websocket-accept` from http response")
+        .ne(&handshake::accept_key_from(sec_key))
+    {
+        return Err(DIDCacheError::TransportError(
+            "invalid websocket accept key".to_string(),
+        ));
+    }
+
+    Ok(WebSocket::client(stream))
+}

--- a/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/affinidi-did-resolver-cache-server/Cargo.toml
@@ -27,6 +27,7 @@ serde_json.workspace = true
 ssi.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-rustls.workspace = true
 toml.workspace = true
 tower-http.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
* MAINTENANCE: Rust 2024 Edition enabled by default (2021 --> 2024)
* MAINTENANCE: Crates updated
* UPDATE: affinidi-did-resolver-cache-sdk
  * tokio-tungstenite removed and replaced via web-socket crate
  * Enables better low level error handling of the WebSocket. Especially when a device sleeps and detecting the WebSocket Channel has been closed.