### PR TITLE
release 0.4.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Changelog history
 
+### ?? March 2025 (release 0.4.1)
+
+* Added Minimum Supported Rust Version 1.85
+
 ### 4th March 2025 (release 0.4.0)
 
 * MAINTENANCE: Crates updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,10 @@
 
 ## Changelog history
 
-### ?? March 2025 (release 0.4.1)
-
-* Added Minimum Supported Rust Version 1.85
-
 ### 4th March 2025 (release 0.4.0)
 
 * MAINTENANCE: Crates updated
+* Added Minimum Supported Rust Version 1.85
 * Breaking Change: ClientConfig and ClientConfigBuilder renamed
   * ClientConfig --> DIDCacheConfig
   * ClientConfigBuilder --> DIDCacheConfigBuilder

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ keywords = ["did", "ssi"]
 publish = true
 license = "Apache-2.0"
 repository = "https://github.com/affinidi/affinidi-did-resolver"
+rust-version = "1.85"
 
 [workspace.dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ repository = "https://github.com/affinidi/affinidi-did-resolver"
 rust-version = "1.85"
 
 [workspace.dependencies]
+affinidi-did-resolver-cache-sdk = { version = "0.4", path = "./affinidi-did-resolver-cache-sdk" }
+did-peer = { version = "0.4", path = "./affinidi-did-resolver-methods/did-peer" }
+did-example = { version = "0.4", path = "./affinidi-did-resolver-methods/did-example" }
 
 # Common Dependencies
 moka = { version = "0.12", features = ["future"] }
@@ -37,9 +40,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Cache Server
-affinidi-did-resolver-cache-sdk = { path = "./affinidi-did-resolver-cache-sdk" }
-did-peer = { path = "./affinidi-did-resolver-methods/did-peer" }
-did-example = { path = "./affinidi-did-resolver-methods/did-example" }
 axum = { version = "0.8", features = ["ws"] }
 axum-extra = { version = "0.10", features = ["typed-header"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }

--- a/affinidi-did-resolver-cache-sdk/Cargo.toml
+++ b/affinidi-did-resolver-cache-sdk/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 license.workspace = true
 repository.workspace = true
 readme = "README.md"
+rust-version.workspace = true
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/affinidi-did-resolver-cache-server/Cargo.toml
+++ b/affinidi-did-resolver-cache-server/Cargo.toml
@@ -10,6 +10,7 @@ publish.workspace = true
 license.workspace = true
 repository.workspace = true
 readme = "README.md"
+rust-version.workspace = true
 
 [dependencies]
 affinidi-did-resolver-cache-sdk = { workspace = true, features = ["network"] }

--- a/affinidi-did-resolver-methods/Cargo.toml
+++ b/affinidi-did-resolver-methods/Cargo.toml
@@ -10,3 +10,4 @@ keywords.workspace = true
 publish.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true

--- a/affinidi-did-resolver-methods/did-example/Cargo.toml
+++ b/affinidi-did-resolver-methods/did-example/Cargo.toml
@@ -10,6 +10,7 @@ keywords.workspace = true
 publish.workspace = true
 license.workspace = true
 readme = "README.md"
+rust-version.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/affinidi-did-resolver-methods/did-peer/Cargo.toml
+++ b/affinidi-did-resolver-methods/did-peer/Cargo.toml
@@ -10,6 +10,7 @@ keywords.workspace = true
 publish.workspace = true
 license.workspace = true
 readme = "README.md"
+rust-version.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
### 4th March 2025 (release 0.4.0)

* MAINTENANCE: Crates updated
* Added Minimum Supported Rust Version 1.85
* Breaking Change: ClientConfig and ClientConfigBuilder renamed
  * ClientConfig --> DIDCacheConfig
  * ClientConfigBuilder --> DIDCacheConfigBuilder